### PR TITLE
implements bmp_create w/ correct array allocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: c
 
 compiler:
-  - gcc
   - clang
 
 addons:
@@ -30,7 +29,7 @@ install:
 
 before_script:
   - mkdir build && cd $_
-  - cmake -Dfssim_tests=ON ..
+  - cmake ..
   - make
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 # setup
 cmake_minimum_required(VERSION 2.8)
 option(fssim_tests "Include Tests." ON)
-option(CMAKE_BUILD_TYPE "Debug")
 
 set(PROJECT_NAME fssim)
 project(${PROJECT_NAME} C)

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ $ cmake ..
 $ ./fssim
 ```
 
-If you wish to test the project as well you might be interested on having the verbose output when a test fails. To enable such feature, add the following variable to your environment:
+If you wish to test the project as well you might be interested on having the verbose output when a test fails. To enable such feature, add the following variable to your environment and run `cmake` w/ `Debug` set up:
 
 ```
 $ export CTEST_OUTPUT_ON_FAILURE=1
+$ cmake -DCMAKE_BUILD_TYPE=Debug ..
 ```
 
 ## Inner Workings

--- a/include/fssim/bmp.h
+++ b/include/fssim/bmp.h
@@ -4,11 +4,11 @@
 #include "fssim/common.h"
 
 #define FS_BMP_IS_ON_(__bmp, __pos)                                            \
-  (CHECK_LBIT(__bmp->mapping[(__pos / 8 | 0)], (__pos % 8)))
+  (CHECK_LBIT(__bmp->mapping[(__pos / 8)], (__pos % 8)))
 
 #define FS_BMP_FLIP_(__bmp, __pos)                                             \
   do {                                                                         \
-    SET_LBIT(__bmp->mapping[(__pos / 8 | 0)], (__pos % 8));                    \
+    SET_LBIT(__bmp->mapping[(__pos / 8)], (__pos % 8));                        \
   } while (0);
 
 /**
@@ -21,13 +21,21 @@
 typedef struct fs_bmp_t {
   size_t size;
   size_t num_blocks;
+  uint32_t last_block;
   uint8_t* mapping;
 } fs_bmp_t;
 
 fs_bmp_t* fs_bmp_create(size_t size);
 void fs_bmp_destroy(fs_bmp_t* bmp);
 
+/**
+ * Frees the given space
+ */
 void fs_bmp_free(fs_bmp_t* bmp, uint32_t block);
+
+/**
+ * Searches for a free space (next fit)
+ */
 uint32_t fs_bmp_alloc(fs_bmp_t* bmp);
 
 #endif

--- a/include/fssim/bmp.h
+++ b/include/fssim/bmp.h
@@ -3,21 +3,6 @@
 
 #include "fssim/common.h"
 
-#define FS_BMP_IS_ON_(__bmp, __pos)                                            \
-  (CHECK_LBIT(__bmp->mapping[(__pos / 8)], (__pos % 8)))
-
-#define FS_BMP_FLIP_(__bmp, __pos)                                             \
-  do {                                                                         \
-    SET_LBIT(__bmp->mapping[(__pos / 8)], (__pos % 8));                        \
-  } while (0);
-
-/**
- * BITMAP
- *
- * bit(0) --> free
- * bit(1) --> occupied
- */
-
 typedef struct fs_bmp_t {
   size_t size;
   size_t num_blocks;
@@ -25,17 +10,34 @@ typedef struct fs_bmp_t {
   uint8_t* mapping;
 } fs_bmp_t;
 
+/**
+ * Creates a bitmap that maps <size> blocks.
+ */
 fs_bmp_t* fs_bmp_create(size_t size);
+
+/**
+ * Destroys the bitmap
+ */
 void fs_bmp_destroy(fs_bmp_t* bmp);
 
 /**
- * Frees the given space
+ * Frees the given space.
  */
 void fs_bmp_free(fs_bmp_t* bmp, uint32_t block);
 
 /**
- * Searches for a free space (next fit)
+ * Searches for free space  w/ a next-fit
+ * strategy, sets the bit (now used) and returns
+ * the block ref
  */
 uint32_t fs_bmp_alloc(fs_bmp_t* bmp);
+
+#define FS_BMP_IS_ON_(__bmp, __pos)                                            \
+  (CHECK_LBIT(__bmp->mapping[(__pos / 8)], (__pos % 8)))
+
+#define FS_BMP_FLIP_(__bmp, __pos)                                             \
+  do {                                                                         \
+    SET_LBIT(__bmp->mapping[(__pos / 8)], (__pos % 8));                        \
+  } while (0);
 
 #endif

--- a/include/fssim/bmp.h
+++ b/include/fssim/bmp.h
@@ -22,4 +22,7 @@ void fs_bmp_destroy(fs_bmp_t* bmp);
 void fs_bmp_free(fs_bmp_t* bmp, uint32_t block);
 uint32_t fs_bmp_alloc(fs_bmp_t* bmp);
 
+int fs_bmp_IS_ON_(fs_bmp_t* bmp, int pos);
+void fs_bmp_FLIP_(fs_bmp_t* bmp, int pos);
+
 #endif

--- a/include/fssim/bmp.h
+++ b/include/fssim/bmp.h
@@ -1,7 +1,15 @@
 #ifndef FSSIM__BMP_H
-#define FSSIM__BMP_H 
+#define FSSIM__BMP_H
 
 #include "fssim/common.h"
+
+#define FS_BMP_IS_ON_(__bmp, __pos)                                            \
+  (CHECK_LBIT(__bmp->mapping[(__pos / 8 | 0)], (__pos % 8)))
+
+#define FS_BMP_FLIP_(__bmp, __pos)                                             \
+  do {                                                                         \
+    SET_LBIT(__bmp->mapping[(__pos / 8 | 0)], (__pos % 8));                    \
+  } while (0);
 
 /**
  * BITMAP
@@ -21,8 +29,5 @@ void fs_bmp_destroy(fs_bmp_t* bmp);
 
 void fs_bmp_free(fs_bmp_t* bmp, uint32_t block);
 uint32_t fs_bmp_alloc(fs_bmp_t* bmp);
-
-int fs_bmp_IS_ON_(fs_bmp_t* bmp, int pos);
-void fs_bmp_FLIP_(fs_bmp_t* bmp, int pos);
 
 #endif

--- a/include/fssim/bmp.h
+++ b/include/fssim/bmp.h
@@ -12,6 +12,7 @@
 
 typedef struct fs_bmp_t {
   size_t size;
+  size_t num_blocks;
   uint8_t* mapping;
 } fs_bmp_t;
 

--- a/include/fssim/common.h
+++ b/include/fssim/common.h
@@ -1,6 +1,17 @@
 #ifndef FSSIM_COMMON_H
 #define FSSIM_COMMON_H
 
+#define CHECK_RBIT(__var, __pos) ((__var) & (1 << (__pos)))
+#define CHECK_LBIT(__var, __pos) ((__var) & (128 >> (__pos)))
+#define SET_LBIT(__var, __pos)                                                 \
+  do {                                                                         \
+    __var ^= (128 >> __pos);                                                   \
+  } while (0);
+#define SET_RBIT(__var, __pos)                                                 \
+  do {                                                                         \
+    __var ^= (1 << __pos);                                                     \
+  } while (0);
+
 #include "fssim/constants.h"
 
 #include <stdlib.h>
@@ -88,4 +99,3 @@ inline static int fexists(const char* fname)
 }
 
 #endif // ! FSSIM_COMMON_H
-

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -24,7 +24,8 @@ void fs_bmp_destroy(fs_bmp_t* bmp)
   free(bmp);
 }
 
-void fs_bmp_free(fs_bmp_t* bmp, uint32_t block) {
+void fs_bmp_free(fs_bmp_t* bmp, uint32_t block)
+{
   if (FS_BMP_IS_ON_(bmp, block)) {
     FS_BMP_FLIP_(bmp, block);
   } else {
@@ -32,16 +33,16 @@ void fs_bmp_free(fs_bmp_t* bmp, uint32_t block) {
   }
 }
 
-uint32_t fs_bmp_alloc(fs_bmp_t* bmp) { 
+uint32_t fs_bmp_alloc(fs_bmp_t* bmp)
+{
   while (1) {
     if (!FS_BMP_IS_ON_(bmp, bmp->last_block)) {
       FS_BMP_FLIP_(bmp, bmp->last_block);
       return bmp->last_block;
     }
 
-    bmp->last_block = (bmp->last_block+1) % bmp->num_blocks;
+    bmp->last_block = (bmp->last_block + 1) % bmp->num_blocks;
   }
 
   ASSERT(0, "fs_bmp_alloc(): No free space found");
 }
-

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -2,14 +2,17 @@
 
 fs_bmp_t* fs_bmp_create(size_t size)
 {
+  ASSERT(size, "Size must be at least > 0");
+
   fs_bmp_t* bmp = malloc(sizeof(*bmp));
   PASSERT(bmp, FS_ERR_MALLOC);
 
-  bmp->size = size;
-  bmp->mapping = calloc(size, sizeof(*bmp->mapping));
+  bmp->num_blocks = size;
+  bmp->size = ((size - 1) / 8 | 0) + 1;
+  bmp->mapping = calloc(bmp->size, sizeof(*bmp->mapping));
   PASSERT(bmp->mapping, FS_ERR_MALLOC);
 
-  memset(bmp->mapping, 0x00, size);
+  memset(bmp->mapping, 0x00, bmp->size);
 
   return bmp;
 }
@@ -20,12 +23,6 @@ void fs_bmp_destroy(fs_bmp_t* bmp)
   free(bmp);
 }
 
-void fs_bmp_free(fs_bmp_t* bmp, uint32_t block)
-{
-}
+void fs_bmp_free(fs_bmp_t* bmp, uint32_t block) {}
 
-uint32_t fs_bmp_alloc(fs_bmp_t* bmp)
-{
-  return 1;
-}
-
+uint32_t fs_bmp_alloc(fs_bmp_t* bmp) { return 1; }

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -24,28 +24,5 @@ void fs_bmp_destroy(fs_bmp_t* bmp)
 }
 
 void fs_bmp_free(fs_bmp_t* bmp, uint32_t block) {}
-
 uint32_t fs_bmp_alloc(fs_bmp_t* bmp) { return 1; }
-
-int fs_bmp_IS_ON_(fs_bmp_t* bmp, int pos)
-{
-  int offset = pos % 8;
-  int index = pos / 8 | 0;
-
-  ASSERT(index < bmp->size, "BMP bounds error: %d is not a valid position",
-         pos);
-
-  LOGERR("offset = %d, index = %d", offset, index);
-
-  return CHECK_LBIT(bmp->mapping[index], offset);
-}
-
-
-void fs_bmp_FLIP_(fs_bmp_t* bmp, int pos)
-{
-  int offset = pos % 8;
-  int index = pos / 8 | 0;
-
-  SET_LBIT(bmp->mapping[index], offset);
-}
 

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -26,3 +26,26 @@ void fs_bmp_destroy(fs_bmp_t* bmp)
 void fs_bmp_free(fs_bmp_t* bmp, uint32_t block) {}
 
 uint32_t fs_bmp_alloc(fs_bmp_t* bmp) { return 1; }
+
+int fs_bmp_IS_ON_(fs_bmp_t* bmp, int pos)
+{
+  int offset = pos % 8;
+  int index = pos / 8 | 0;
+
+  ASSERT(index < bmp->size, "BMP bounds error: %d is not a valid position",
+         pos);
+
+  LOGERR("offset = %d, index = %d", offset, index);
+
+  return CHECK_LBIT(bmp->mapping[index], offset);
+}
+
+
+void fs_bmp_FLIP_(fs_bmp_t* bmp, int pos)
+{
+  int offset = pos % 8;
+  int index = pos / 8 | 0;
+
+  SET_LBIT(bmp->mapping[index], offset);
+}
+

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -7,6 +7,7 @@ fs_bmp_t* fs_bmp_create(size_t size)
   fs_bmp_t* bmp = malloc(sizeof(*bmp));
   PASSERT(bmp, FS_ERR_MALLOC);
 
+  bmp->last_block = 0;
   bmp->num_blocks = size;
   bmp->size = ((size - 1) / 8 | 0) + 1;
   bmp->mapping = calloc(bmp->size, sizeof(*bmp->mapping));
@@ -23,6 +24,24 @@ void fs_bmp_destroy(fs_bmp_t* bmp)
   free(bmp);
 }
 
-void fs_bmp_free(fs_bmp_t* bmp, uint32_t block) {}
-uint32_t fs_bmp_alloc(fs_bmp_t* bmp) { return 1; }
+void fs_bmp_free(fs_bmp_t* bmp, uint32_t block) {
+  if (FS_BMP_IS_ON_(bmp, block)) {
+    FS_BMP_FLIP_(bmp, block);
+  } else {
+    LOGERR("already freed block %d passed to `fs_bmp_free`.", block);
+  }
+}
+
+uint32_t fs_bmp_alloc(fs_bmp_t* bmp) { 
+  while (1) {
+    if (!FS_BMP_IS_ON_(bmp, bmp->last_block)) {
+      FS_BMP_FLIP_(bmp, bmp->last_block);
+      return bmp->last_block;
+    }
+
+    bmp->last_block = (bmp->last_block+1) % bmp->num_blocks;
+  }
+
+  ASSERT(0, "fs_bmp_alloc(): No free space found");
+}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,9 +8,9 @@ foreach(file ${tests})
   add_executable(${testname} ${file})
   target_link_libraries(${testname} ${fssim_LIBRARIES})
 
-  add_test(NAME "memcheck_${testname}"
-           COMMAND valgrind --leak-check=yes --error-exitcode=1 ./${testname})
   add_test(NAME ${testname} 
            COMMAND ${testname}) 
+  add_test(NAME "memcheck_${testname}"
+           COMMAND valgrind --leak-check=yes --error-exitcode=1 ./${testname})
 
 endforeach()

--- a/tests/test-bmp.c
+++ b/tests/test-bmp.c
@@ -30,13 +30,45 @@ void test2()
   size_t blocks = 16;
   fs_bmp_t* bmp = fs_bmp_create(blocks);
 
+  ASSERT(bmp->mapping[0] == 0x00, "Initialily [00000000]");
+  ASSERT(bmp->mapping[1] == 0x00, "Initialily [00000000]");
+
+  SET_LBIT(bmp->mapping[0], 0);
+  ASSERT(bmp->mapping[0] == 128, "");
+  SET_LBIT(bmp->mapping[0], 7);
+  ASSERT(bmp->mapping[0] == 129, "");
+
+  ASSERT(fs_bmp_IS_ON_(bmp, 0), "");
+  ASSERT(fs_bmp_IS_ON_(bmp, 7), "");
+
+  SET_LBIT(bmp->mapping[1], 7);
+  LOGERR("bmp->mapping[1] = %d", bmp->mapping[1]);
+  ASSERT(fs_bmp_IS_ON_(bmp, 15), "");
+
+  fs_bmp_destroy(bmp);
+}
+
+void test3()
+{
+  size_t blocks = 16;
+  fs_bmp_t* bmp = fs_bmp_create(blocks);
+
+  fs_bmp_FLIP_(bmp, 0);
+  fs_bmp_FLIP_(bmp, 5);
+  fs_bmp_FLIP_(bmp, 15);
+
+  ASSERT(CHECK_LBIT(bmp->mapping[0], 0), "");
+  ASSERT(CHECK_LBIT(bmp->mapping[0], 5), "");
+  ASSERT(CHECK_LBIT(bmp->mapping[1], 7), "");
+
   fs_bmp_destroy(bmp);
 }
 
 int main(int argc, char* argv[])
 {
   TEST(test1, "creation and deletion");
-  TEST(test2, "bit flipping and retrieval");
+  TEST(test2, "bit value checker");
+  TEST(test3, "bit flipper");
 
   return 0;
 }

--- a/tests/test-bmp.c
+++ b/tests/test-bmp.c
@@ -38,12 +38,12 @@ void test2()
   SET_LBIT(bmp->mapping[0], 7);
   ASSERT(bmp->mapping[0] == 129, "");
 
-  ASSERT(fs_bmp_IS_ON_(bmp, 0), "");
-  ASSERT(fs_bmp_IS_ON_(bmp, 7), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 0), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 7), "");
 
   SET_LBIT(bmp->mapping[1], 7);
   LOGERR("bmp->mapping[1] = %d", bmp->mapping[1]);
-  ASSERT(fs_bmp_IS_ON_(bmp, 15), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 15), "");
 
   fs_bmp_destroy(bmp);
 }
@@ -53,9 +53,9 @@ void test3()
   size_t blocks = 16;
   fs_bmp_t* bmp = fs_bmp_create(blocks);
 
-  fs_bmp_FLIP_(bmp, 0);
-  fs_bmp_FLIP_(bmp, 5);
-  fs_bmp_FLIP_(bmp, 15);
+  FS_BMP_FLIP_(bmp, 0);
+  FS_BMP_FLIP_(bmp, 5);
+  FS_BMP_FLIP_(bmp, 15);
 
   ASSERT(CHECK_LBIT(bmp->mapping[0], 0), "");
   ASSERT(CHECK_LBIT(bmp->mapping[0], 5), "");

--- a/tests/test-bmp.c
+++ b/tests/test-bmp.c
@@ -3,16 +3,40 @@
 
 void test1()
 {
-  size_t blocks = 1024;
+  {
+    size_t blocks = 1024;
+    fs_bmp_t* bmp = fs_bmp_create(blocks);
+
+    ASSERT(bmp->num_blocks == 1024, "");
+    ASSERT(bmp->size == 128,
+           "The size of the bmp must equal the # of uint8 entries it has");
+
+    fs_bmp_destroy(bmp);
+  }
+  {
+    size_t blocks = 1025;
+    fs_bmp_t* bmp = fs_bmp_create(blocks);
+
+    ASSERT(bmp->num_blocks == 1025, "");
+    ASSERT(bmp->size == 129,
+           "The size of the bmp must equal the # of uint8 entries it has");
+
+    fs_bmp_destroy(bmp);
+  }
+}
+
+void test2()
+{
+  size_t blocks = 16;
   fs_bmp_t* bmp = fs_bmp_create(blocks);
 
   fs_bmp_destroy(bmp);
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
   TEST(test1, "creation and deletion");
-  
+  TEST(test2, "bit flipping and retrieval");
+
   return 0;
 }
-

--- a/tests/test-bmp.c
+++ b/tests/test-bmp.c
@@ -33,14 +33,16 @@ void test2()
   ASSERT(bmp->mapping[0] == 0x00, "Initialily [00000000]");
   ASSERT(bmp->mapping[1] == 0x00, "Initialily [00000000]");
 
-  SET_LBIT(bmp->mapping[0], 0);
+  SET_LBIT(bmp->mapping[0], 0); // 0b10000000
   ASSERT(bmp->mapping[0] == 128, "");
-  SET_LBIT(bmp->mapping[0], 7);
+  SET_LBIT(bmp->mapping[0], 7); // 0b10000001
   ASSERT(bmp->mapping[0] == 129, "");
 
   ASSERT(FS_BMP_IS_ON_(bmp, 0), "");
   ASSERT(FS_BMP_IS_ON_(bmp, 7), "");
 
+  // 0b1000001
+  // 0b0000001
   SET_LBIT(bmp->mapping[1], 7);
   LOGERR("bmp->mapping[1] = %d", bmp->mapping[1]);
   ASSERT(FS_BMP_IS_ON_(bmp, 15), "");
@@ -53,13 +55,97 @@ void test3()
   size_t blocks = 16;
   fs_bmp_t* bmp = fs_bmp_create(blocks);
 
+  // 0b10000000
+  // 0b00000000
   FS_BMP_FLIP_(bmp, 0);
+  // 0b10000100
+  // 0b00000000
   FS_BMP_FLIP_(bmp, 5);
+  // 0b10000100
+  // 0b00000001
   FS_BMP_FLIP_(bmp, 15);
 
-  ASSERT(CHECK_LBIT(bmp->mapping[0], 0), "");
-  ASSERT(CHECK_LBIT(bmp->mapping[0], 5), "");
-  ASSERT(CHECK_LBIT(bmp->mapping[1], 7), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 0), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 5), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 15), "");
+
+  fs_bmp_destroy(bmp);
+}
+
+void test4()
+{
+  size_t blocks = 8;
+  fs_bmp_t* bmp = fs_bmp_create(blocks);
+
+  uint32_t b0 = fs_bmp_alloc(bmp);
+  uint32_t b1 = fs_bmp_alloc(bmp);
+  uint32_t b2 = fs_bmp_alloc(bmp);
+
+  ASSERT(b0 == 0, "");
+  ASSERT(b1 == 1, "");
+  ASSERT(b2 == 2, "");
+  //   !!
+  // 0b11100000
+
+  ASSERT(FS_BMP_IS_ON_(bmp, 0), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 1), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 2), "");
+
+  //      !!!
+  // 0b11111100
+  FS_BMP_FLIP_(bmp, 3);
+  FS_BMP_FLIP_(bmp, 4);
+  FS_BMP_FLIP_(bmp, 5);
+
+  //         !!
+  // 0b11111110
+  uint32_t b6 = fs_bmp_alloc(bmp);
+  uint32_t b7 = fs_bmp_alloc(bmp);
+
+  ASSERT(b6 == 6, "");
+  ASSERT(b7 == 7, "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 6), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 7), "");
+
+  //     !!
+  // 0b11001111
+  FS_BMP_FLIP_(bmp, 2);
+  FS_BMP_FLIP_(bmp, 3);
+  ASSERT(!FS_BMP_IS_ON_(bmp, 2), "");
+  ASSERT(!FS_BMP_IS_ON_(bmp, 3), "");
+
+  //     !!
+  // 0b11111111
+  b2 = fs_bmp_alloc(bmp);
+  uint32_t b3 = fs_bmp_alloc(bmp);
+  ASSERT(b2 == 2, "");
+  ASSERT(b3 == 3, "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 2), "");
+  ASSERT(FS_BMP_IS_ON_(bmp, 3), "");
+
+  fs_bmp_destroy(bmp);
+}
+
+void test5()
+{
+  size_t blocks = 16;
+  fs_bmp_t* bmp = fs_bmp_create(blocks);
+
+  //         !
+  // 0b0000001
+  // 0b0000000
+  FS_BMP_FLIP_(bmp, 7);
+  bmp->last_block = 7;
+
+  ASSERT(FS_BMP_IS_ON_(bmp, 7), "");
+  ASSERT(!FS_BMP_IS_ON_(bmp, 8), "");
+
+  //         !
+  // 0b0000001
+  //   !
+  // 0b0000000
+  uint32_t b8 = fs_bmp_alloc(bmp);
+  ASSERT(FS_BMP_IS_ON_(bmp, 8), "");
 
   fs_bmp_destroy(bmp);
 }
@@ -69,6 +155,8 @@ int main(int argc, char* argv[])
   TEST(test1, "creation and deletion");
   TEST(test2, "bit value checker");
   TEST(test3, "bit flipper");
+  TEST(test4, "block alloc");
+  TEST(test5, "block alloc - multiple rows");
 
   return 0;
 }


### PR DESCRIPTION
This PR implements BMP, which holds a list of `uint8_t`s that has all of the bits responsible for indicating whether or not a given block is free in disk. 

```
BLOCKS
     U       U      U  U
[1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19]

BMP:
1 : [00100010]
1 : [01100000]
1 : [00000000]
```
